### PR TITLE
Add encryption support for Kinesis Firehose, S3 Bucket, and SNS topic

### DIFF
--- a/examples/encryption_enabled_all_resources/README.md
+++ b/examples/encryption_enabled_all_resources/README.md
@@ -1,0 +1,35 @@
+# Integrate EKS cluster(s) Audit Logs with Lacework - Encryption Enabled
+
+This example creates all the required resources, as well as an IAM Role with a cross-account policy to 
+provide Lacework read-only access to monitor the audit logs.
+
+Additionally, this example encrypts the Kinesis Firehose, S3 Bucket, and SNS Topic with a generated KMS key by default. No additional inputs need to be set for encryption to be enabled.
+
+## Inputs
+
+| Name                        | Description                                                                                               | Type           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------- | -------------- |
+| `cloudwatch_regions`        | A list of regions, to allow Cloudwatch Logs to be streamed from                                           | `list(string)` |
+| `cluster_names`             | A set of cluster names, to integrate with. Defaults to [] if `no_cw_subscription_filter` is set to `true` | `set(string)`  |
+
+## Sample Code
+
+```terraform
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_eks_audit_log" {
+  source                    = "lacework/eks-audit-log/aws"
+  version                   = "~> 0.2"
+  cloudwatch_regions        = ["us-west-2"]
+  cluster_names             = ["my-tf-cluster"]
+}
+```
+
+## Things to note
+With the default settings, the module will create a new KMS key and use it to encrypt the Kinesis Firehose, S3 Bucket, and SNS Topic.
+
+

--- a/examples/encryption_enabled_all_resources/main.tf
+++ b/examples/encryption_enabled_all_resources/main.tf
@@ -1,0 +1,11 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_eks_audit_log" {
+  source                    = "../.."
+  cloudwatch_regions        = ["us-west-2"]
+  cluster_name              = ["my-tf-cluster"]
+}

--- a/examples/encryption_enabled_all_resources/versions.tf
+++ b/examples/encryption_enabled_all_resources/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/examples/encryption_enabled_existing_kms_key/README.md
+++ b/examples/encryption_enabled_existing_kms_key/README.md
@@ -1,0 +1,41 @@
+# Integrate EKS cluster(s) Audit Logs with Lacework - Encryption Enabled on S3 Only
+
+This example creates all the required resources, as well as an IAM Role with a cross-account policy to 
+provide Lacework read-only access to monitor the audit logs.
+
+Additionally, this example encrypts the Kinesis Firehose, S3 Bucket, and SNS Topic with a preexisting KMS key.
+
+## Inputs
+
+| Name                                  | Description                                                                                                                               | Type           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `cloudwatch_regions`                  | A list of regions, to allow Cloudwatch Logs to be streamed from                                                                           | `list(string)` |
+| `cluster_names`                       | A set of cluster names, to integrate with. Defaults to [] if `no_cw_subscription_filter` is set to `true`                                 | `set(string)`  |
+| `bucket_sse_key_arn`                  | The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms` and using an existing aws_kms_key) | `string` | 
+| `kinesis_firehose_encryption_key_arn` | The ARN of an existing KMS encryption key to be used for the Kinesis Firehose                                                             | `string`         |
+| `sns_topic_encryption_key_arn`        | The ARN of an existing KMS encryption key to be used for the SNS topic                                                                    | `string`         |
+
+## Sample Code
+
+```terraform
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_eks_audit_log" {
+  source                              = "lacework/eks-audit-log/aws"
+  version                             = "~> 0.2"
+  cloudwatch_regions                  = ["us-west-2"]
+  cluster_names                       = ["my-tf-cluster"]
+  bucket_sse_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  kinesis_firehose_encryption_key_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  sns_topic_encryption_key_arn        = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+}
+```
+
+## Things to note
+When an ARN is supplied for either the Firehose, bucket, or topic, the module will use the supplied KMS key.
+
+If one (or two) of the three resouces doesn't use a supplied/existing key, a KMS key will be created and that resource(s) will use the KMS key created. So it is possible to use both a created and an existing key.

--- a/examples/encryption_enabled_existing_kms_key/main.tf
+++ b/examples/encryption_enabled_existing_kms_key/main.tf
@@ -1,0 +1,15 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_eks_audit_log" {
+  source                              = "lacework/eks-audit-log/aws"
+  version                             = "~> 0.2"
+  cloudwatch_regions                  = ["us-west-2"]
+  cluster_names                       = ["my-tf-cluster"]
+  bucket_sse_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  kinesis_firehose_encryption_key_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  sns_topic_encryption_key_arn        = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+}

--- a/examples/encryption_enabled_existing_kms_key/versions.tf
+++ b/examples/encryption_enabled_existing_kms_key/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/examples/encryption_enabled_s3_only/README.md
+++ b/examples/encryption_enabled_s3_only/README.md
@@ -1,0 +1,37 @@
+# Integrate EKS cluster(s) Audit Logs with Lacework - Encryption Enabled on S3 Only
+
+This example creates all the required resources, as well as an IAM Role with a cross-account policy to 
+provide Lacework read-only access to monitor the audit logs.
+
+Additionally, this example encrypts the S3 Bucket only, the Kinesis Firehose and SNS Topic are not. A KMS key is generated.
+
+## Inputs
+
+| Name                                  | Description                                                                                               | Type           |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------- |
+| `cloudwatch_regions`                  | A list of regions, to allow Cloudwatch Logs to be streamed from                                           | `list(string)` |
+| `cluster_names`                       | A set of cluster names, to integrate with. Defaults to [] if `no_cw_subscription_filter` is set to `true` | `set(string)`  |
+| `kinesis_firehose_encryption_enabled` | Set this to `false` to disable encryption on the Kinesis Firehose. Defaults to `true`                     | `bool`         |
+| `sns_topic_encryption_enabled`        | Set this to `false` to disable encryption on the sns topic. Defaults to `true`                            | `bool`         |
+
+## Sample Code
+
+```terraform
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_eks_audit_log" {
+  source                              = "lacework/eks-audit-log/aws"
+  version                             = "~> 0.2"
+  cloudwatch_regions                  = ["us-west-2"]
+  cluster_names                       = ["my-tf-cluster"]
+  kinesis_firehose_encryption_enabled = false
+  sns_topic_encryption_enabled        = false
+}
+```
+
+## Things to note
+With the default settings, the module will create a new KMS key and use it to encrypt the S3 Bucket.

--- a/examples/encryption_enabled_s3_only/main.tf
+++ b/examples/encryption_enabled_s3_only/main.tf
@@ -1,0 +1,14 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_eks_audit_log" {
+  source                              = "lacework/eks-audit-log/aws"
+  version                             = "~> 0.2"
+  cloudwatch_regions                  = ["us-west-2"]
+  cluster_names                       = ["my-tf-cluster"]
+  kinesis_firehose_encryption_enabled = false
+  sns_topic_encryption_enabled        = false
+}

--- a/examples/encryption_enabled_s3_only/versions.tf
+++ b/examples/encryption_enabled_s3_only/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,63 @@ variable "wait_time" {
   default     = "10s"
   description = "Amount of time between setting up AWS resources, and creating the Lacework integration."
 }
+
+variable "bucket_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "Set this to `true` to enable encryption on a created S3 bucket"
+}
+
+variable "bucket_sse_algorithm" {
+  type        = string
+  default     = "aws:kms"
+  description = "The encryption algorithm to use for S3 bucket server-side encryption"
+}
+
+variable "bucket_sse_key_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms` and using an existing aws_kms_key)"
+}
+
+variable "kms_key_rotation" {
+  type        = bool
+  default     = true
+  description = "Enable KMS automatic key rotation"
+}
+
+variable "kms_key_deletion_days" {
+  type        = number
+  default     = 30
+  description = "The waiting period, specified in number of days"
+}
+
+variable "kms_key_multi_region" {
+  type        = bool
+  default     = true
+  description = "Whether the KMS key is a multi-region or regional key"
+}
+
+variable "kinesis_firehose_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "Set this to `false` to disable encryption on the Kinesis Firehose. Defaults to true"
+}
+
+variable "kinesis_firehose_encryption_key_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of an existing KMS encryption key to be used for the Kinesis Firehose"
+}
+
+variable "sns_topic_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "Set this to `false` to disable encryption on the sns topic. Defaults to true"
+}
+
+variable "sns_topic_encryption_key_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of an existing KMS encryption key to be used for the SNS topic"
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Customer has requirements to encrypt all AWS resources where data is stored at rest. This code enables encryption (by default) on resources created for the EKS audit log capabilities of Lacework: the Kinesis Firehose, S3 bucket, and SNS topic. Resources can have encryption enabled/disabled individually. By default this code will create a new KMS key to encrypt these resources, however a user can specify an existing key ARN to encrypt the resources as well.

## How did you test this change?

Multiple tests were performed: 1) Enabled encryption on all resources (Firehose,S3,SNS) with created KMS key 2) enable encryption only on certain combinations (Firehose+SNS, Firehose+S3, S3+SNS, etc) 3) disable all encryption 4) Enabled encryption on all resources with existing KMS key (with the right key policy permissions).

## Issue

https://lacework.atlassian.net/browse/ALLY-1077