### PR TITLE
ci: add new examples to ci_tests.sh

### DIFF
--- a/examples/encryption_enabled_all_resources/README.md
+++ b/examples/encryption_enabled_all_resources/README.md
@@ -22,10 +22,10 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                    = "lacework/eks-audit-log/aws"
-  version                   = "~> 0.2"
-  cloudwatch_regions        = ["us-west-2"]
-  cluster_names             = ["my-tf-cluster"]
+  source             = "lacework/eks-audit-log/aws"
+  version            = "~> 0.3"
+  cloudwatch_regions = ["us-west-2"]
+  cluster_names      = ["my-tf-cluster"]
 }
 ```
 

--- a/examples/encryption_enabled_all_resources/main.tf
+++ b/examples/encryption_enabled_all_resources/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                    = "../.."
-  cloudwatch_regions        = ["us-west-2"]
-  cluster_name              = ["my-tf-cluster"]
+  source             = "../.."
+  cloudwatch_regions = ["us-west-2"]
+  cluster_names      = ["my-tf-cluster"]
 }

--- a/examples/encryption_enabled_existing_kms_key/README.md
+++ b/examples/encryption_enabled_existing_kms_key/README.md
@@ -26,7 +26,7 @@ provider "aws" {
 
 module "aws_eks_audit_log" {
   source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.2"
+  version                             = "~> 0.3"
   cloudwatch_regions                  = ["us-west-2"]
   cluster_names                       = ["my-tf-cluster"]
   bucket_sse_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"

--- a/examples/encryption_enabled_existing_kms_key/main.tf
+++ b/examples/encryption_enabled_existing_kms_key/main.tf
@@ -5,8 +5,7 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.2"
+  source                              = "../.."
   cloudwatch_regions                  = ["us-west-2"]
   cluster_names                       = ["my-tf-cluster"]
   bucket_sse_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"

--- a/examples/encryption_enabled_s3_only/README.md
+++ b/examples/encryption_enabled_s3_only/README.md
@@ -25,7 +25,7 @@ provider "aws" {
 
 module "aws_eks_audit_log" {
   source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.2"
+  version                             = "~> 0.3"
   cloudwatch_regions                  = ["us-west-2"]
   cluster_names                       = ["my-tf-cluster"]
   kinesis_firehose_encryption_enabled = false

--- a/examples/encryption_enabled_s3_only/main.tf
+++ b/examples/encryption_enabled_s3_only/main.tf
@@ -5,8 +5,7 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.2"
+  source                              = "../.."
   cloudwatch_regions                  = ["us-west-2"]
   cluster_names                       = ["my-tf-cluster"]
   kinesis_firehose_encryption_enabled = false

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -11,6 +11,9 @@ readonly project_name=terraform-aws-eks-audit-log
 TEST_CASES=(
   examples/default
   examples/multi_region
+  examples/encryption_enabled_all_resources
+  examples/encryption_enabled_existing_kms_key
+  examples/encryption_enabled_s3_only
 )
 
 log() {


### PR DESCRIPTION

## Summary

Addin new examples from https://github.com/lacework/terraform-aws-eks-audit-log/pull/6 to our `ci_tests.sh` script

## How did you test this change?

By running the pipeline.

## Issue

https://lacework.atlassian.net/browse/ALLY-1077