### PR TITLE
fix firehose encryption logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
   bucket_encryption_enabled           = var.bucket_encryption_enabled && length(local.bucket_sse_key_arn) > 0
   bucket_sse_key_arn                  = var.bucket_encryption_enabled ? (length(var.bucket_sse_key_arn) > 0 ? var.bucket_sse_key_arn : aws_kms_key.lacework_eks_kms_key[0].arn) : ""
   sns_topic_key_arn                   = var.sns_topic_encryption_enabled ? (length(var.sns_topic_encryption_key_arn) > 0 ? var.sns_topic_encryption_key_arn : aws_kms_key.lacework_eks_kms_key[0].arn) : ""
-  kinesis_firehose_encryption_enabled = var.kinesis_firehose_encryption_enabled && length(var.kinesis_firehose_encryption_key_arn) > 0
+  kinesis_firehose_encryption_enabled = var.kinesis_firehose_encryption_enabled && length(local.kinesis_firehose_encryption_key_arn) > 0
   kinesis_firehose_key_arn            = var.kinesis_firehose_encryption_enabled ? (length(var.kinesis_firehose_encryption_key_arn) > 0 ? var.kinesis_firehose_encryption_key_arn : aws_kms_key.lacework_eks_kms_key[0].arn) : ""
 }
 


### PR DESCRIPTION
## Summary

The logic to enable the Kinesis firehose encryption was flawed because it referred to "var.kinesis_firehose_encryption_key_arn" rather than "local.kinesis_firehose_encryption_key_arn" (which has additional logic). Switching from the var to local ensures that encryption is enabled if it is set to be enabled and the local key arn exists.

## How did you test this change?

Tests performed: 1) ensure kinesis encryption was enabled with default settings 2) ensure kinesis encryption was enabled when a key arn was supplied and set to be enabled 3) ensure kinesis encryption was disabled when a key arn was supplied and set to be disabled

## Issue

n/a