### PR TITLE
fix: Re-add firehose_arn output

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 | <a name="output_external_id"></a> [external\_id](#output\_external\_id) | The External ID configured into the IAM role |
 | <a name="output_filter_pattern"></a> [filter\_pattern](#output\_filter\_pattern) | The Cloudwatch Log Subscription Filter pattern |
 | <a name="output_filter_prefix"></a> [filter\_prefix](#output\_filter\_prefix) | The Cloudwatch Log Subscription filter prefix |
-| <a name="output_firehose_arn"></a> [firehose\_arn](#output\_firehose\_arn) | The Firehose IAM Role ARN |
+| <a name="output_firehose_arn"></a> [firehose\_arn](#output\_firehose\_arn) | The Firehose delivery stream ARN |
+| <a name="output_firehose_iam_role_arn"></a> [firehose\_iam\_role\_arn](#output\_firehose\_iam\_role\_arn) | The Firehose IAM Role ARN |
 | <a name="output_firehose_iam_role_name"></a> [firehose\_iam\_role\_name](#output\_firehose\_iam\_role\_name) | The Firehose IAM Role name |
 | <a name="output_sns_arn"></a> [sns\_arn](#output\_sns\_arn) | SNS Topic ARN |
 | <a name="output_sns_name"></a> [sns\_name](#output\_sns\_name) | SNS Topic name |

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_log_subscription_filter" "lacework_cw_subscription_filt
   role_arn        = module.aws_eks_audit_log.cloudwatch_iam_role_arn
   log_group_name  = "/aws/eks/${each.value}/cluster"
   filter_pattern  = module.aws_eks_audit_log.filter_pattern
-  destination_arn = module.aws_eks_audit_log.firehose_iam_role_arn
+  destination_arn = module.aws_eks_audit_log.firehose_arn
   depends_on      = [module.aws_eks_audit_log]
 }
 
@@ -37,6 +37,6 @@ resource "aws_cloudwatch_log_subscription_filter" "lacework_cw_subscription_filt
   role_arn        = module.aws_eks_audit_log.cloudwatch_iam_role_arn
   log_group_name  = "/aws/eks/${each.value}/cluster"
   filter_pattern  = module.aws_eks_audit_log.filter_pattern
-  destination_arn = module.aws_eks_audit_log.firehose_iam_role_arn
+  destination_arn = module.aws_eks_audit_log.firehose_arn
   depends_on      = [module.aws_eks_audit_log]
 }

--- a/output.tf
+++ b/output.tf
@@ -42,6 +42,12 @@ output "filter_pattern" {
   value       = var.filter_pattern
   description = "The Cloudwatch Log Subscription Filter pattern"
 }
+
+output "firehose_arn" {
+  value       = aws_kinesis_firehose_delivery_stream.extended_s3_stream.arn
+  description = "The Firehose delivery stream ARN"
+}
+
 output "firehose_iam_role_arn" {
   value       = local.firehose_iam_role_arn
   description = "The Firehose IAM Role ARN"


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>


## Summary
Unfortunately we unintentionally removed the firehose_arn output in a previous PR.

## How did you test this change?
