### PR TITLE
docs: update Lacework provider version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
-| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.17 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
 
@@ -47,7 +47,7 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.17 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
 


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0 in readme

[_Created by Sourcegraph batch change `darren.murray/terraform-readme`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-readme)