### PR TITLE
fix: ci tfsec scan

### DIFF
--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -41,9 +41,15 @@ lint_tests() {
   terraform fmt -check
 }
 
+sec_tests() {
+  # TODO: replace with `lacework iac tf-scan tfsec -m MEDIUM`
+  tfsec -m MEDIUM
+}
+
 main() {
   lint_tests
   integration_tests
+  sec_tests
 }
 
 main || exit 99


### PR DESCRIPTION
## Summary

Running `tfsec` in the nightly CI automation

## Issue

https://lacework.atlassian.net/browse/GROW-1322
https://github.com/lacework/terraform-aws-eks-audit-log/issues/14