### PR TITLE
fix: s3 bucket ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 | [aws_iam_policy_document.firehose_iam_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.firehose_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_s3_bucket_ownership_controls.eks_audit_log_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.log_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource 
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -214,6 +214,14 @@ resource "aws_s3_bucket" "eks_audit_log_bucket" {
   tags          = var.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "eks_audit_log_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.eks_audit_log_bucket.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "bucket_access" {
   bucket                  = aws_s3_bucket.eks_audit_log_bucket.id
   block_public_acls       = true
@@ -278,6 +286,15 @@ resource "aws_s3_bucket" "log_bucket" {
   bucket        = local.log_bucket_name
   force_destroy = var.bucket_force_destroy
   tags          = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership_controls" {
+  count  = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : 1)
+  bucket = aws_s3_bucket.log_bucket[0].id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "log_bucket_access" {


### PR DESCRIPTION
## Summary

To enable bucket ACL the ObjectOwnership parameter must be set to ObjectWriter.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

## How did you test this change?

`terraform plan`

## Issue

https://lacework.atlassian.net/browse/GROW-1534