### PR TITLE
feat: Allow user defined S3 Bucket for the audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 | <a name="sns_topic_encryption_enabled"></a> [sns\_topic\_encryption\_enabled](#sns\_topic\_encryption\_enabled) | Set this to `false` to disable encryption on the sns topic. Defaults to true | `bool` | `true` | no |
 | <a name="sns_topic_encryption_key_arn"></a> [sns\_topic\_encryption\_key\_arn](#sns\_topic\_encryption\_key\_arn) | The ARN of an existing KMS encryption key to be used for the SNS topic | `string` | `""` | no |
 | <a name="input_use_existing_access_log_bucket"></a> [use\_existing\_access\_log\_bucket](#input\_use\_existing\_access\_log\_bucket) | Set this to `true` to use an existing bucket for access logging. Default behavior creates a new access log bucket if logging is enabled | `bool` | `false` | no |
+| <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | The S3 bucket ARN is required when setting use\_existing\_bucket to true | `string` | `""` | no |
+| <a name="input_use_existing_bucket"></a> [use\_existing\_bucket](#input\_use\_existing\_bucket) | Set this to true to use an existing S3 Bucket. Default behavior creates a new S3 Bucket | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/use_existing_bucket/main.tf
+++ b/examples/use_existing_bucket/main.tf
@@ -1,0 +1,9 @@
+provider "lacework" {}
+
+module "aws_eks_audit_log" {
+  source              = "../.."
+  cloudwatch_regions  = ["us-west-2"]
+  cluster_names       = ["example_cluster"]
+  use_existing_bucket = true
+  bucket_arn          = "arn:aws:s3:::dev5-cloud-account-registrar-lacework"
+}

--- a/examples/use_existing_bucket/versions.tf
+++ b/examples/use_existing_bucket/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "bucket_arn" {
-  value       = aws_s3_bucket.eks_audit_log_bucket.arn
+  value       = local.bucket_arn
   description = "Lacework AWS EKS Audit Log S3 Bucket ARN"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -206,3 +206,15 @@ variable "use_existing_access_log_bucket" {
   default     = false
   description = "Set this to `true` to use an existing bucket for access logging. Default behavior creates a new access log bucket if logging is enabled"
 }
+
+variable "bucket_arn" {
+  type        = string
+  default     = ""
+  description = "The S3 bucket ARN is required when setting use_existing_bucket to true"
+}
+
+variable "use_existing_bucket" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to use an existing bucket for the logs. Default behavior creates a new log bucket"
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
This allows the user to reference their own already existing S3 bucket for use with the Audit Log, they user indicates this by setting the `use_existing_bucket` flag to `true`, and setting the bucket ARN in the `bucket_arn` field
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Added new examples directory with user supplied S3 bucket ARN,  ran `terraform plan` to check resources created correctly, also ran the default example which does not have a supplied S3 Bucket ARN and checked that Bucket and resources were created correctly
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/GROW-1519
<!--
  Include the link to a Jira/Github issue
-->