### PR TITLE
fix(RAIN-58160): [eks] - Least privilege for Firehose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -543,16 +543,8 @@ data "aws_iam_policy_document" "eks_cw_iam_role_policy" {
 
   statement {
     actions = [
-      "firehose:CreateDeliveryStream",
-      "firehose:DeleteDeliveryStream",
-      "firehose:DescribeDeliveryStream",
       "firehose:PutRecord",
-      "firehose:PutRecordBatch",
-      "firehose:StartDeliveryStreamEncryption",
-      "firehose:StopDeliveryStreamEncryption",
-      "firehose:TagDeliveryStream",
-      "firehose:UntagDeliveryStream",
-      "firehose:ListTagsForDeliveryStream"
+      "firehose:PutRecordBatch"
     ]
     effect    = "Allow"
     resources = ["arn:aws:firehose:*:${data.aws_caller_identity.current.account_id}:deliverystream/${local.firehose_delivery_stream_name}"]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
Apply least privileges for Firehose created for EKS 
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Tested in dev3
Created new subscription filter with the changes and confirmed rows loaded in SF 
<img width="977" alt="Screenshot 2023-05-08 at 1 08 44 PM" src="https://github.com/lacework/rainbow/assets/25260196/2c50e99a-47ee-45a6-be71-1aeac0ca2249">
<img width="1404" alt="Screenshot 2023-05-08 at 1 10 02 PM" src="https://github.com/lacework/rainbow/assets/25260196/acc2b476-35b4-45d7-be57-e85a5962f7d9">

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/RAIN-58158
<!--
  Include the link to a Jira/Github issue
-->