### PR TITLE
feat: Add support for AWS provider 5.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -398,8 +398,8 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
     role_arn            = local.firehose_iam_role_arn
     bucket_arn          = local.bucket_arn
     prefix              = "eks_audit_logs/${data.aws_caller_identity.current.account_id}/"
-    buffer_interval     = 300
-    buffer_size         = 100
+    buffering_interval     = 300
+    buffering_size         = 100
     error_output_prefix = "audit_logs/${data.aws_caller_identity.current.account_id}/error/"
     compression_format  = "UNCOMPRESSED"
     cloudwatch_logging_options {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
 
   required_providers {
-    aws    = ">= 4.0"
+    aws    = ">= 5.0"
     random = ">= 2.1"
     time   = "~> 0.6"
     lacework = {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
 
   required_providers {
-    aws    = "~> 4.0"
+    aws    = ">= 4.0"
     random = ">= 2.1"
     time   = "~> 0.6"
     lacework = {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This upgrade needs to drop support of AWS v4 following guidance from https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#resourceaws_kinesis_firehose_delivery_stream

## How did you test this change?

- [ ] Terraform compatibility tests

## Issue

https://lacework.atlassian.net/browse/GROW-1713