### PR TITLE
fix: avoid S3 bucket race condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -584,6 +584,8 @@ data "aws_arn" "cloudwatch_iam_role" {
 
 # wait for X seconds for things to settle down in the AWS side
 # before trying to create the Lacework external integration
+#
+# https://github.com/hashicorp/terraform-provider-aws/issues/31139
 resource "time_sleep" "wait_time_cw" {
   create_duration = var.wait_time
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "tags" {
 
 variable "wait_time" {
   type        = string
-  default     = "10s"
+  default     = "20s"
   description = "Amount of time between setting up AWS resources, and creating the Lacework integration."
 }
 


### PR DESCRIPTION
## Summary

AWS S3 bucket race condition.  Increase sleep time to avoid this.

https://github.com/hashicorp/terraform-provider-aws/issues/31139

## Issue

https://lacework.atlassian.net/browse/GROW-2271