### PR TITLE
chore: enable bucket_force_destroy by default

### DIFF
--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -94,7 +94,6 @@ module "aws_cloudtrail" {
   source  = "lacework/cloudtrail/aws"
   version = "~> 0.1"
 
-  bucket_force_destroy  = true
   use_existing_iam_role = true
   iam_role_name         = module.aws_config.iam_role_name
   iam_role_arn          = module.aws_config.iam_role_arn

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_log_prefix"></a> [access\_log\_prefix](#input\_access\_log\_prefix) | Optional value to specify a key prefix for access log objects for logging S3 bucket | `string` | `"log/"` | no |
 | <a name="input_bucket_enable_mfa_delete"></a> [bucket\_enable\_mfa\_delete](#input\_bucket\_enable\_mfa\_delete) | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
-| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (Required when bucket not empty) | `bool` | `false` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket) | `bool` | `true` | no |
 | <a name="input_bucket_lifecycle_expiration_days"></a> [bucket\_lifecycle\_expiration\_days](#input\_bucket\_lifecycle\_expiration\_days) | The lifetime, in days, of the bucket objects. The value must be a non-zero positive integer. | `number` | `180` | no |
 | <a name="input_bucket_logs_disabled"></a> [bucket\_logs\_disabled](#input\_bucket\_logs\_enabled) | Set this to `true` to disable access logging on a created S3 bucket | `bool` | `false` | no |
 | <a name="input_bucket_versioning_enabled"></a> [bucket\_versioning\_enabled](#input\_bucket\_versioning\_enabled) | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `true` | no |

--- a/examples/custom_filter/README.md
+++ b/examples/custom_filter/README.md
@@ -17,36 +17,37 @@ provide Lacework read-only access to monitor the audit logs, and provides a cust
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source             = "lacework/eks-audit-log/aws"
-  version            = "~> 0.2"
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.2"
+
   cloudwatch_regions = ["us-west-1"]
   cluster_names      = ["example_cluster"]
-  filter_pattern = join (" ",
-                         [ "{",
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"leases\" ||",
-                           "$.verb != \"update\" ||",
-                           "$.user.username != \"system:*\") &&",
+  filter_pattern = join(" ",
+    ["{",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"leases\" ||",
+      "$.verb != \"update\" ||",
+      "$.user.username != \"system:*\") &&",
 
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"configmaps\" ||",
-                           "$.verb != \"watch\" ||",
-                           "$.user.username != \"system:node:*\") &&",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"configmaps\" ||",
+      "$.verb != \"watch\" ||",
+      "$.user.username != \"system:node:*\") &&",
 
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"configmaps\" ||",
-                           "$.verb != \"update\" ||",
-                           "($.user.username != \"system:serviceaccounts:*\" &&",
-                           "$.user.username != \"system:eks:certificate-controller\")) &&",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"configmaps\" ||",
+      "$.verb != \"update\" ||",
+      "($.user.username != \"system:serviceaccounts:*\" &&",
+      "$.user.username != \"system:eks:certificate-controller\")) &&",
 
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"endpoints\" ||",
-                           "$.verb != \"update\" ||",
-                           "($.user.username != \"system:serviceaccounts:*\" &&",
-                           "$.user.username != \"system:eks:certificate-controller\"))",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"endpoints\" ||",
+      "$.verb != \"update\" ||",
+      "($.user.username != \"system:serviceaccounts:*\" &&",
+      "$.user.username != \"system:eks:certificate-controller\"))",
 
-                         "}"]
-  )  
+    "}"]
+  )
 }
 ```
 

--- a/examples/custom_filter/main.tf
+++ b/examples/custom_filter/main.tf
@@ -1,33 +1,34 @@
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source             = "../.."
+  source = "../.."
+
   cloudwatch_regions = ["us-west-1"]
   cluster_names      = ["example_cluster"]
-  filter_pattern = join (" ",
-                         [ "{",
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"leases\" ||",
-                           "$.verb != \"update\" ||",
-                           "$.user.username != \"system:*\") &&",
+  filter_pattern = join(" ",
+    ["{",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"leases\" ||",
+      "$.verb != \"update\" ||",
+      "$.user.username != \"system:*\") &&",
 
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"configmaps\" ||",
-                           "$.verb != \"watch\" ||",
-                           "$.user.username != \"system:node:*\") &&",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"configmaps\" ||",
+      "$.verb != \"watch\" ||",
+      "$.user.username != \"system:node:*\") &&",
 
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"configmaps\" ||",
-                           "$.verb != \"update\" ||",
-                           "($.user.username != \"system:serviceaccounts:*\" &&",
-                           "$.user.username != \"system:eks:certificate-controller\")) &&",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"configmaps\" ||",
+      "$.verb != \"update\" ||",
+      "($.user.username != \"system:serviceaccounts:*\" &&",
+      "$.user.username != \"system:eks:certificate-controller\")) &&",
 
-                           "($.responseStatus.code != 200 ||",
-                           "$.objectRef.resource != \"endpoints\" ||",
-                           "$.verb != \"update\" ||",
-                           "($.user.username != \"system:serviceaccounts:*\" &&",
-                           "$.user.username != \"system:eks:certificate-controller\"))",
+      "($.responseStatus.code != 200 ||",
+      "$.objectRef.resource != \"endpoints\" ||",
+      "$.verb != \"update\" ||",
+      "($.user.username != \"system:serviceaccounts:*\" &&",
+      "$.user.username != \"system:eks:certificate-controller\"))",
 
-                         "}"]
+    "}"]
   )
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -16,8 +16,9 @@ provide Lacework read-only access to monitor the audit logs.
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source             = "lacework/eks-audit-log/aws"
-  version            = "~> 0.2"
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.2"
+
   cloudwatch_regions = ["us-west-1"]
   cluster_names      = ["example_cluster"]
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,7 +1,8 @@
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source             = "../.."
+  source = "../.."
+
   cloudwatch_regions = ["us-west-1"]
   cluster_names      = ["example_cluster"]
 }

--- a/examples/encryption_enabled_all_resources/README.md
+++ b/examples/encryption_enabled_all_resources/README.md
@@ -22,8 +22,9 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source             = "lacework/eks-audit-log/aws"
-  version            = "~> 0.3"
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.3"
+
   cloudwatch_regions = ["us-west-2"]
   cluster_names      = ["my-tf-cluster"]
 }

--- a/examples/encryption_enabled_all_resources/main.tf
+++ b/examples/encryption_enabled_all_resources/main.tf
@@ -5,7 +5,8 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source             = "../.."
+  source = "../.."
+
   cloudwatch_regions = ["us-west-2"]
   cluster_names      = ["my-tf-cluster"]
 }

--- a/examples/encryption_enabled_existing_kms_key/README.md
+++ b/examples/encryption_enabled_existing_kms_key/README.md
@@ -7,13 +7,13 @@ Additionally, this example encrypts the Kinesis Firehose, S3 Bucket, and SNS Top
 
 ## Inputs
 
-| Name                                  | Description                                                                                                                               | Type           |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `cloudwatch_regions`                  | A list of regions, to allow Cloudwatch Logs to be streamed from                                                                           | `list(string)` |
-| `cluster_names`                       | A set of cluster names, to integrate with. Defaults to [] if `no_cw_subscription_filter` is set to `true`                                 | `set(string)`  |
-| `bucket_sse_key_arn`                  | The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms` and using an existing aws_kms_key) | `string` | 
-| `kinesis_firehose_encryption_key_arn` | The ARN of an existing KMS encryption key to be used for the Kinesis Firehose                                                             | `string`         |
-| `sns_topic_encryption_key_arn`        | The ARN of an existing KMS encryption key to be used for the SNS topic                                                                    | `string`         |
+| Name                       | Description                                                                                                                               | Type           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `cloudwatch_regions`       | A list of regions, to allow Cloudwatch Logs to be streamed from                                                                           | `list(string)` |
+| `cluster_names`            | A set of cluster names, to integrate with. Defaults to [] if `no_cw_subscription_filter` is set to `true`                                 | `set(string)`  |
+| `bucket_key_arn`           | The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms` and using an existing aws_kms_key) | `string`       |
+| `kinesis_firehose_key_arn` | The ARN of an existing KMS encryption key to be used for the Kinesis Firehose                                                             | `string`       |
+| `sns_topic_key_arn`        | The ARN of an existing KMS encryption key to be used for the SNS topic                                                                    | `string`       |
 
 ## Sample Code
 
@@ -25,13 +25,14 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.3"
-  cloudwatch_regions                  = ["us-west-2"]
-  cluster_names                       = ["my-tf-cluster"]
-  bucket_sse_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
-  kinesis_firehose_encryption_key_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
-  sns_topic_encryption_key_arn        = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.3"
+
+  cloudwatch_regions       = ["us-west-2"]
+  cluster_names            = ["my-tf-cluster"]
+  bucket_key_arn           = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  kinesis_firehose_key_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  sns_topic_key_arn        = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
 }
 ```
 

--- a/examples/encryption_enabled_existing_kms_key/main.tf
+++ b/examples/encryption_enabled_existing_kms_key/main.tf
@@ -5,10 +5,11 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                              = "../.."
-  cloudwatch_regions                  = ["us-west-2"]
-  cluster_names                       = ["my-tf-cluster"]
-  bucket_key_arn                      = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
-  kinesis_firehose_key_arn            = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
-  sns_topic_key_arn                   = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  source = "../.."
+
+  cloudwatch_regions       = ["us-west-2"]
+  cluster_names            = ["my-tf-cluster"]
+  bucket_key_arn           = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  kinesis_firehose_key_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
+  sns_topic_key_arn        = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234567890abcdefghijklmnopqrstuv"
 }

--- a/examples/encryption_enabled_s3_only/README.md
+++ b/examples/encryption_enabled_s3_only/README.md
@@ -24,8 +24,9 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.3"
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.3"
+
   cloudwatch_regions                  = ["us-west-2"]
   cluster_names                       = ["my-tf-cluster"]
   kinesis_firehose_encryption_enabled = false

--- a/examples/encryption_enabled_s3_only/main.tf
+++ b/examples/encryption_enabled_s3_only/main.tf
@@ -5,7 +5,8 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                              = "../.."
+  source = "../.."
+
   cloudwatch_regions                  = ["us-west-2"]
   cluster_names                       = ["my-tf-cluster"]
   kinesis_firehose_encryption_enabled = false

--- a/examples/multi_region/README.md
+++ b/examples/multi_region/README.md
@@ -29,8 +29,9 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                    = "lacework/eks-audit-log/aws"
-  version                   = "~> 0.2"
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.2"
+
   cloudwatch_regions        = ["eu-west-1", "us-west-2"]
   no_cw_subscription_filter = true
 }
@@ -38,7 +39,6 @@ module "aws_eks_audit_log" {
 resource "aws_cloudwatch_log_subscription_filter" "lacework_cw_subscription_filter-eu-west" {
   for_each = toset(["cluster-1", "cluster-2"])
   provider = aws.eu-west-1
-
 
   name            = "${module.aws_eks_audit_log.filter_prefix}-${each.value}"
   role_arn        = module.aws_eks_audit_log.cloudwatch_iam_role_arn

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -11,7 +11,8 @@ provider "aws" {
 }
 
 module "aws_eks_audit_log" {
-  source                    = "../.."
+  source = "../.."
+
   cloudwatch_regions        = ["eu-west-1", "us-west-2"]
   no_cw_subscription_filter = true
 }
@@ -19,7 +20,6 @@ module "aws_eks_audit_log" {
 resource "aws_cloudwatch_log_subscription_filter" "lacework_cw_subscription_filter-eu-west" {
   for_each = toset(["cluster-1", "cluster-2"])
   provider = aws.eu-west-1
-
 
   name            = "${module.aws_eks_audit_log.filter_prefix}-${each.value}"
   role_arn        = module.aws_eks_audit_log.cloudwatch_iam_role_arn

--- a/examples/use_existing_bucket/README.md
+++ b/examples/use_existing_bucket/README.md
@@ -18,9 +18,10 @@ with a cross-account policy to provide Lacework read-only access to monitor the 
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source              = "lacework/eks-audit-log/aws"
-  version             = "~> 0.5"
-  cloudwatch_regions  = ["us-west-1"]
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.5"
+
+  cloudwatch_regions  = ["us-west-2"]
   cluster_names       = ["example_cluster"]
   use_existing_bucket = true
   bucket_arn          = "arn:aws:s3:::lacework-eks-bucket-8805c0bf"

--- a/examples/use_existing_bucket/main.tf
+++ b/examples/use_existing_bucket/main.tf
@@ -1,7 +1,8 @@
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source              = "../.."
+  source = "../.."
+
   cloudwatch_regions  = ["us-west-2"]
   cluster_names       = ["example_cluster"]
   use_existing_bucket = true

--- a/examples/use_existing_iam_roles/README.md
+++ b/examples/use_existing_iam_roles/README.md
@@ -24,9 +24,10 @@ prior to use.
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source                              = "lacework/eks-audit-log/aws"
-  version                             = "~> 0.4"
-  cloudwatch_regions                  = ["us-east-1"]
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.4"
+
+  cloudwatch_regions                  = ["us-west-1"]
   cluster_names                       = ["example_cluster"]
   use_existing_cross_account_iam_role = true
   iam_role_arn                        = "arn:aws:iam::123456789012:role/my-ca-role"

--- a/examples/use_existing_iam_roles/main.tf
+++ b/examples/use_existing_iam_roles/main.tf
@@ -1,7 +1,8 @@
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source                              = "../.."
+  source = "../.."
+
   cloudwatch_regions                  = ["us-west-1"]
   cluster_names                       = ["example_cluster"]
   use_existing_cross_account_iam_role = true

--- a/variables.tf
+++ b/variables.tf
@@ -30,8 +30,8 @@ variable "bucket_logs_disabled" {
 
 variable "bucket_force_destroy" {
   type        = bool
-  default     = false
-  description = "Force destroy bucket (Required when bucket not empty)"
+  default     = true
+  description = "Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket)"
 }
 
 variable "cloudwatch_regions" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

When we use this module to automatically deploy and rollback changes. Users are having
constant issues trying to destroy the S3 bucket if it is not empty. To unblock this problem,
users need to turn on the `bucket_force_destroy` flag, and then do any modification that
requires a "destroy" operation.

By default, we should allow users to do these operations without the need to know about
this flag, if users does not wish to allow these buckets to be destroyed when they are not
empty, users should switch off the flag with `bucket_force_destroy = false`.

## How did you test this change?

After merge, we will run our internal pipeline https://github.com/lacework/terraform-customerdemo/pull/70

## Issue
https://lacework.atlassian.net/browse/GROW-1336
