### PR TITLE
fix: Limit IAM permissions for EKS

### DIFF
--- a/examples/allow_debugging_permissions/README.md
+++ b/examples/allow_debugging_permissions/README.md
@@ -17,7 +17,8 @@ provide Lacework read-only access to monitor the audit logs, and enables debuggi
 provider "lacework" {}
 
 module "aws_eks_audit_log" {
-  source = "../.."
+  source  = "lacework/eks-audit-log/aws"
+  version = "~> 0.2"
 
   cloudwatch_regions  = ["us-west-2"]
   cluster_names       = ["example_cluster"]

--- a/examples/allow_debugging_permissions/README.md
+++ b/examples/allow_debugging_permissions/README.md
@@ -1,0 +1,28 @@
+# Integrate EKS cluster(s) Audit Logs with Lacework - Single Region
+
+This example creates all the required resources, as well as an IAM Role with a cross-account policy to
+provide Lacework read-only access to monitor the audit logs, and enables debugging permissions
+
+## Inputs
+
+| Name                          | Description                                                                                               | Type           |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------|----------------|
+| `cloudwatch_regions`          | A list of regions, to allow Cloudwatch Logs to be streamed from                                           | `list(string)` |
+| `cluster_names`               | A set of cluster names, to integrate with. Defaults to [] if `no_cw_subscription_filter` is set to `true` | `set(string)`  |
+| `allow_debugging_permissions` | A boolean that can enable debugging permissions                                                           | `boolean`      |
+
+## Sample Code
+
+```terraform
+provider "lacework" {}
+
+module "aws_eks_audit_log" {
+  source = "../.."
+
+  cloudwatch_regions  = ["us-west-2"]
+  cluster_names       = ["example_cluster"]
+  allow_debugging_permissions = true
+}
+```
+
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).

--- a/examples/allow_debugging_permissions/main.tf
+++ b/examples/allow_debugging_permissions/main.tf
@@ -1,0 +1,9 @@
+provider "lacework" {}
+
+module "aws_eks_audit_log" {
+  source = "../.."
+
+  cloudwatch_regions  = ["us-west-2"]
+  cluster_names       = ["example_cluster"]
+  allow_debugging_permissions = true
+}

--- a/examples/allow_debugging_permissions/versions.tf
+++ b/examples/allow_debugging_permissions/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -485,7 +485,7 @@ data "aws_iam_policy_document" "eks_cross_account_policy" {
         "firehose:DescribeDeliveryStream"
       ]
       effect    = "Allow"
-      resources = "*"
+      resources = ["*"]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -456,15 +456,6 @@ data "aws_iam_policy_document" "eks_cross_account_policy" {
   }
 
   statement {
-    sid = "CloudWatchLogsPermissions"
-    actions = [
-      "logs:DescribeSubscriptionFilters"
-    ]
-    effect    = "Allow"
-    resources = [local.cloudwatch_permission_resources]
-  }
-
-  statement {
     sid = "SNSPermissions"
     actions = [
       "sns:GetTopicAttributes",
@@ -476,19 +467,40 @@ data "aws_iam_policy_document" "eks_cross_account_policy" {
   }
 
   statement {
-    sid = "FirehosePermissions"
-    actions = [
-      "firehose:DescribeDeliveryStream"
-    ]
-    effect    = "Allow"
-    resources = [aws_kinesis_firehose_delivery_stream.extended_s3_stream.arn]
-  }
-
-  statement {
     sid       = "AccountAliasPermissions"
     actions   = ["iam:ListAccountAliases"]
     effect    = "Allow"
     resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.allow_debugging_permissions ? [1] : []
+    content {
+      sid     = "DebugPermissions"
+      actions = [
+        "eks:ListClusters",
+        "logs:DescribeLogGroups",
+        "logs:DescribeSubscriptionFilters",
+        "firehose:ListDeliveryStreams",
+        "firehose:DescribeDeliveryStream"
+      ]
+      effect    = "Allow"
+      resources = "*"
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.allow_debugging_permissions ? [1] : []
+    content {
+      sid     = "S3DebugPermissions"
+      actions = [
+        "s3:GetBucketAcl",
+        "s3:GetBucketLocation",
+        "s3:GetBucketNotificationConfiguration"
+      ]
+      effect    = "Allow"
+      resources = local.bucket_arn
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -499,7 +499,7 @@ data "aws_iam_policy_document" "eks_cross_account_policy" {
         "s3:GetBucketNotificationConfiguration"
       ]
       effect    = "Allow"
-      resources = local.bucket_arn
+      resources = [local.bucket_arn]
     }
   }
 }

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -15,6 +15,7 @@ TEST_CASES=(
   examples/encryption_enabled_all_resources
   examples/encryption_enabled_existing_kms_key
   examples/encryption_enabled_s3_only
+  examples/allow_debugging_permissions
 )
 
 log() {

--- a/variables.tf
+++ b/variables.tf
@@ -218,3 +218,9 @@ variable "use_existing_bucket" {
   default     = false
   description = "Set this to `true` to use an existing bucket for the logs. Default behavior creates a new log bucket"
 }
+
+variable "allow_debugging_permissions" {
+  type        = bool
+  default     = false
+  description = "To allow debugging permissions, set this parameter to true"
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Review and limit IAM permissions for EKS Audit Logs Terraform template to adhere to least privilege
## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
https://lacework.atlassian.net/wiki/spaces/ENG/pages/2060877955/EKS+K8s+Audit+Ingestion+Design+Document#Data-Flow - Trimmed permissions using this to understand functionality of the different resources
Tested in dev3
Created resources in devtest-sandbox account
Tested cases with and without debugging permissions and validated no issues

## Issue
https://lacework.atlassian.net/browse/RAIN-58162
<!--
  Include the link to a Jira/Github issue
-->