### PR TITLE
fix: Add S3 bucket arn to integration

### DIFF
--- a/examples/use_existing_bucket/main.tf
+++ b/examples/use_existing_bucket/main.tf
@@ -1,10 +1,16 @@
 provider "lacework" {}
 
+# Configure the AWS Provider
+provider "aws" {}
+
+
 module "aws_eks_audit_log" {
   source = "../.."
 
   cloudwatch_regions  = ["us-west-2"]
-  cluster_names       = ["example_cluster"]
+  no_cw_subscription_filter = true
+  cluster_names       = []
   use_existing_bucket = true
-  bucket_arn          = "arn:aws:s3:::dev5-cloud-account-registrar-lacework"
+  tags                = { Name = "my-test-tag-1"}
+  bucket_arn          = "arn:aws:s3:::dmct-2320-2-laceworkcws-8f04"
 }

--- a/main.tf
+++ b/main.tf
@@ -590,6 +590,7 @@ resource "time_sleep" "wait_time_cw" {
 resource "lacework_integration_aws_eks_audit_log" "data_export" {
   name    = var.integration_name
   sns_arn = aws_sns_topic.eks_sns_topic.arn
+  s3_bucket_arn = local.bucket_arn
   credentials {
     role_arn    = local.iam_role_arn
     external_id = local.iam_role_external_id


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
Addition of the newly created S3 Bucket ARN into the integration so that this can be seen in the UI for that integration

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Ran example Terraform to create integration with S3 bucket creation, checked the UI to see that the created bucket ARN is now shown


![image](https://github.com/lacework/terraform-aws-eks-audit-log/assets/5712253/45abfd93-cb18-410f-b276-eeed9e4d99c6)



## Issue
https://lacework.atlassian.net/browse/GROW-2437