### PR TITLE
docs: Fix 404 URLs to Lacework documentation

### DIFF
--- a/examples/allow_debugging_permissions/README.md
+++ b/examples/allow_debugging_permissions/README.md
@@ -26,4 +26,4 @@ module "aws_eks_audit_log" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.net/onboarding/eks-audit-log-integration-with-terraform).

--- a/examples/custom_filter/README.md
+++ b/examples/custom_filter/README.md
@@ -51,4 +51,4 @@ module "aws_eks_audit_log" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.net/onboarding/eks-audit-log-integration-with-terraform).

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -24,4 +24,4 @@ module "aws_eks_audit_log" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.net/onboarding/eks-audit-log-integration-with-terraform).

--- a/examples/multi_region/README.md
+++ b/examples/multi_region/README.md
@@ -98,4 +98,4 @@ resource "aws_cloudwatch_log_subscription_filter" "lacework_cw_subscription_filt
 }
 ```
 
-For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.net/onboarding/eks-audit-log-integration-with-terraform).

--- a/examples/use_existing_bucket/README.md
+++ b/examples/use_existing_bucket/README.md
@@ -28,4 +28,4 @@ module "aws_eks_audit_log" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.net/onboarding/eks-audit-log-integration-with-terraform).

--- a/examples/use_existing_iam_roles/README.md
+++ b/examples/use_existing_iam_roles/README.md
@@ -39,4 +39,4 @@ module "aws_eks_audit_log" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.com/aws-eks-audit-log-integration-with-terraform).
+For detailed information on integrating Lacework with AWS EKS Audit Logs see [AWS EKS Audit Log Integration with Terraform](https://docs.lacework.net/onboarding/eks-audit-log-integration-with-terraform).


### PR DESCRIPTION
This commit fixes Terraform example pages that have links to Lacework documentation which is outdated and results in a 'Page Not Found' error.  This commit does not change any pages that do not have the link to the Lacework documentation.

## Summary

Several pages within the example modules link to an outdated Lacework documentation URL. This change fixes those links.

## How did you test this change?

Viewed README.md and verified the links go to the proper URLs.

## Issue

Not applicable