### PR TITLE
chore: add var lacework_integration_guid to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ aws eks --region <region> update-cluster-config --name <cluster_name> \
 | <a name="output_firehose_arn"></a> [firehose\_arn](#output\_firehose\_arn) | The Firehose delivery stream ARN |
 | <a name="output_firehose_iam_role_arn"></a> [firehose\_iam\_role\_arn](#output\_firehose\_iam\_role\_arn) | The Firehose IAM Role ARN |
 | <a name="output_firehose_iam_role_name"></a> [firehose\_iam\_role\_name](#output\_firehose\_iam\_role\_name) | The Firehose IAM Role name |
+| <a name="output_lacework_integration_guid"></a> [lacework\_integration\_guid](#output\_lacework\_integration\_guid) | GUID of the created Lacework integration |
 | <a name="output_sns_arn"></a> [sns\_arn](#output\_sns\_arn) | SNS Topic ARN |
 | <a name="output_sns_name"></a> [sns\_name](#output\_sns\_name) | SNS Topic name |
 <!-- END_TF_DOCS -->

--- a/output.tf
+++ b/output.tf
@@ -68,3 +68,7 @@ output "sns_name" {
   description = "SNS Topic name"
 }
 
+output "lacework_integration_guid" {
+  value = length(lacework_integration_aws_eks_audit_log.data_export) > 0 ? lacework_integration_aws_eks_audit_log.data_export.intg_guid : null
+  description = "GUID of the created Lacework integration"
+}


### PR DESCRIPTION
## Summary

Need lacework_integration_guid variable in output for self deployment project.

## How did you test this change?

Tested on dev space. 
<img width="984" height="85" alt="Screenshot 2025-08-20 at 2 52 41 PM" src="https://github.com/user-attachments/assets/2b85b7bb-8d33-4fa1-9683-55993b248e31" />

## Issue

Required for
https://lacework.atlassian.net/jira/software/projects/CAD/boards/373?selectedIssue=CAD-1221