### PR TITLE
chore: add filter block to s3 lifecycle bucket rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -249,6 +249,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "eks_audit_log_bucket_lifecycle
 
   rule {
     id = "eks_audit_log_expiration"
+    filter {}
     expiration {
       days = var.bucket_lifecycle_expiration_days
     }
@@ -328,6 +329,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle_config" {
 
   rule {
     id = "log_expiration"
+    filter {}
     expiration {
       days = var.bucket_lifecycle_expiration_days
     }


### PR DESCRIPTION
## Summary

We get a warning (Invalid Attribute Combination) in lifecycle rule of s3 bucket because atleast one of the attributes (filter or prefix) is to be specified. 
<img width="1377" height="324" alt="Screenshot 2025-09-29 at 2 05 16 PM" src="https://github.com/user-attachments/assets/51f077af-858e-47c9-bea0-1c4aee42fc2c" />


## How did you test this change?

Tested in devspace, ran without warnings. 
<img width="1377" height="324" alt="Screenshot 2025-09-29 at 2 15 26 PM" src="https://github.com/user-attachments/assets/3c172894-8047-4838-a99c-c5a664b458e1" />